### PR TITLE
fix: use api prefix for auth routes

### DIFF
--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -74,9 +74,8 @@ export default function Cadastro() {
     try {
       const emailTrim = form.email.trim().toLowerCase();
 
-      // ⚠️ Chame SEM barra inicial para respeitar baseURL '/api/'
-      // ⚠️ Envie apenas os campos que o backend espera: { email, senha }
-      await api.post('auth/register', {
+      // Caminho absoluto e payload simples esperado pelo backend
+      await api.post('/api/auth/register', {
         email: emailTrim,
         senha: form.senha,
       });

--- a/src/pages/Auth/EsqueciSenha.jsx
+++ b/src/pages/Auth/EsqueciSenha.jsx
@@ -22,7 +22,7 @@ export default function EsqueciSenha() {
     }
     setEnviando(true);
     try {
-      await api.post('auth/forgot-password', { email: email.trim().toLowerCase() });
+      await api.post('/api/auth/forgot-password', { email: email.trim().toLowerCase() });
       setEmailEnviado(true);
       toast.success('Código enviado ao e-mail.');
     } catch (err) {
@@ -46,7 +46,7 @@ export default function EsqueciSenha() {
     setEnviandoConfirmacao(true);
     try {
       // ✅ rota e payload corretos: reset-password com { email, code, novaSenha }
-      await api.post('auth/reset-password', {
+      await api.post('/api/auth/reset-password', {
         email: email.trim().toLowerCase(),
         code: String(codigo).trim(),
         novaSenha: novaSenha.trim(),

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -54,8 +54,8 @@ export default function Login() {
     try {
       setCarregando(true);
 
-      // ⚠️ sem barra inicial para evitar // na URL; normaliza email
-      const { data, status } = await api.post('auth/login', {
+      // Caminho absoluto para evitar duplicação de prefixos
+      const { data, status } = await api.post('/api/auth/login', {
         email: email.trim().toLowerCase(),
         senha: senha.trim(),
       });

--- a/src/pages/Auth/VerificarEmail.jsx
+++ b/src/pages/Auth/VerificarEmail.jsx
@@ -55,7 +55,7 @@ export default function VerificarEmail() {
     try {
       setReenviando(true);
       // ✅ backend: POST /api/auth/resend  { email }
-      await api.post('auth/resend', { email: emailTrim });
+      await api.post('/api/auth/resend', { email: emailTrim });
       setTempo(180);           // reinicia contador (3 min)
       setPodeReenviar(false);  // trava por 30s para evitar spam
       setTimeout(() => setPodeReenviar(true), 30000);
@@ -84,7 +84,7 @@ export default function VerificarEmail() {
     setEnviando(true);
     try {
       // ✅ backend: POST /api/auth/verify  { email, code }
-      await api.post('auth/verify', {
+      await api.post('/api/auth/verify', {
         email: emailTrim,
         code: codeTrim,
       });


### PR DESCRIPTION
## Summary
- fix auth pages to use `/api/auth` prefix

## Testing
- `grep -R "axios.create" -n src | sed -n '1,200p'`
- `grep -R "'/api/api" -n src || true`
- `grep -R "\"/api/api" -n src || true`
- `grep -R "api.get('/v1" -n src || true`
- `grep -R 'api.get("/v1' -n src || true`
- `npm run dev` *(fails: nodemon not found)*
- `npm start`
- `curl http://localhost:3001/api/v1/health`


------
https://chatgpt.com/codex/tasks/task_e_68ac59219a8483288798e754443191df