### PR TITLE
Persist animals via API

### DIFF
--- a/src/pages/Animais/Animais.jsx
+++ b/src/pages/Animais/Animais.jsx
@@ -1,5 +1,5 @@
 // src/pages/Animais/Animais.jsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   ListChecks,
   PlusCircle,
@@ -18,6 +18,7 @@ import Plantel from './Plantel';
 import Secagem from './Secagem';
 import Parto from './Parto';
 import CadastroAnimal from './CadastroAnimal'; // ✅ novo import
+import { getAnimais } from '../../api'; // 🔗 GET /api/v1/animals
 
 /* ---------------------------
    🎨 Personalização central
@@ -127,6 +128,19 @@ export default function Animais() {
   const [animais, setAnimais] = useState([]);
   const [expandido, setExpandido] = useState(false);
 
+  const carregar = async () => {
+    try {
+      const { items } = await getAnimais();
+      setAnimais(items || []);
+    } catch (err) {
+      console.error('Erro ao carregar animais:', err);
+    }
+  };
+
+  useEffect(() => {
+    carregar();
+  }, []);
+
   const atualizarLocal = (novaLista) =>
     setAnimais(Array.isArray(novaLista) ? novaLista : []);
 
@@ -136,7 +150,7 @@ export default function Animais() {
         return (
           <AbasTodos
             animais={animais}
-            onRefresh={() => {}}
+            onRefresh={carregar}
             componentes={{
               plantel: (p) => <Plantel {...p} />,
               secagem: (p) => <Secagem {...p} />,

--- a/src/pages/Animais/CadastroAnimal.jsx
+++ b/src/pages/Animais/CadastroAnimal.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import Select from "react-select";
 import { ImportarFichaTouro, AbrirFichaTouro } from "./FichasTouros";
+import { criarAnimal } from "../../api"; // 🔗 chama POST /api/v1/animals
 
 /* ===========================================
    Helpers inline (sem dependências externas)
@@ -361,32 +362,20 @@ export default function CadastroAnimal({ animais = [], onAtualizar }) {
       return;
     }
 
-    const novo = {
-      numero,
-      brinco,
-      nascimento,
-      sexo,
-      origem,
-      valorCompra: origem === "comprado" ? valorCompra : "",
-      raca,
-      idade,
-      categoria,
-      criadoEm: new Date().toISOString(),
-      status: "ativo",
-      statusReprodutivo: "pos-parto",
-      ultimaAcao: { tipo: "parto", data: nascimento },
-      proximaAcao: { tipo: "fim_pev", dataPrevista: "" },
-      ...complementares,
-    };
-
     try {
       setSalvando(true);
 
-      // TODO: integrar API (PostgreSQL). Exemplo:
-      // const res = await fetch('/api/animais', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(novo) });
-      // if (!res.ok) throw new Error('Falha ao salvar');
-      // const inserido = await res.json();
-      const inserido = novo; // enquanto não integra, só ecoa
+      // 🔗 Persistência real no Postgres (enviar apenas campos do schema do backend)
+      const payload = {
+        numero,
+        brinco,
+        nascimento, // TEXT (dd/mm/aaaa)
+        raca,
+        estado: categoria || "vazia",
+        ...(complementares?.ultimaIA ? { ultima_ia: complementares.ultimaIA } : {}),
+        ...(complementares?.ultimoParto ? { parto: complementares.ultimoParto } : {}),
+      };
+      const inserido = await criarAnimal(payload); // POST /api/v1/animals
 
       onAtualizar?.([...(animais || []), inserido]);
 


### PR DESCRIPTION
## Summary
- Save animal registration via POST `/api/v1/animals`
- Load animal list from API using GET `/api/v1/animals`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adcabf271483288d6388e866b6296c