### PR TITLE
feat: adicionar campos complementares aos animais

### DIFF
--- a/backend/bootstrapResources.js
+++ b/backend/bootstrapResources.js
@@ -11,8 +11,15 @@ export async function ensureTables() {
       nascimento TEXT,
       raca TEXT,
       estado TEXT DEFAULT 'vazia',
+      sexo TEXT,
+      categoria TEXT,
+      pai TEXT,
+      mae TEXT,
+      n_lactacoes INTEGER,
       ultima_ia TEXT,
       parto TEXT,
+      previsao_parto TEXT,
+      historico JSONB,
       created_at TIMESTAMPTZ DEFAULT now()
     );
 
@@ -30,8 +37,17 @@ export async function ensureTables() {
 
     -- Garantir colunas caso a tabela já exista (ambiente que veio antes)
     ALTER TABLE animals  ADD COLUMN IF NOT EXISTS owner_id TEXT;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS sexo TEXT;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS categoria TEXT;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS pai TEXT;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS mae TEXT;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS n_lactacoes INTEGER;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS previsao_parto TEXT;
+    ALTER TABLE animals  ADD COLUMN IF NOT EXISTS historico JSONB;
     ALTER TABLE products ADD COLUMN IF NOT EXISTS owner_id TEXT;
     CREATE INDEX IF NOT EXISTS idx_animals_owner  ON animals(owner_id);
+    CREATE INDEX IF NOT EXISTS idx_animals_num    ON animals(numero);
+    CREATE INDEX IF NOT EXISTS idx_animals_brinco ON animals(brinco);
     CREATE INDEX IF NOT EXISTS idx_products_owner ON products(owner_id);
   `;
   await db.query(sql);

--- a/backend/resources/animals.resource.js
+++ b/backend/resources/animals.resource.js
@@ -7,20 +7,33 @@ import { makeCrudRouter } from './crudRouter.js';
 const createSchema = z.object({
   numero: z.string().optional(),
   brinco: z.string().optional(),
-  nascimento: z.string().optional(), // yyyy-mm-dd
+  nascimento: z.string().optional(), // dd/mm/aaaa (armazenado como TEXT)
   raca: z.string().optional(),
-  estado: z.string().default('vazia'),
-  ultima_ia: z.string().optional(),
-  parto: z.string().optional(),
+  estado: z.string().optional().default('vazia'),
+  sexo: z.string().optional(),                  // 'femea' | 'macho'
+  categoria: z.string().optional(),             // calculada no front, mas salvamos
+  pai: z.string().optional(),
+  mae: z.string().optional(),
+  n_lactacoes: z.coerce.number().int().nonnegative().optional(),
+  ultima_ia: z.string().optional(),             // dd/mm/aaaa
+  parto: z.string().optional(),                 // dd/mm/aaaa (último parto)
+  previsao_parto: z.string().optional(),        // dd/mm/aaaa
+  historico: z.any().optional(),                // JSON com arrays (inseminacoes/partos/secagens)
 });
 const updateSchema = createSchema.partial();
 
 const cfg = {
   table: 'animals',
   id: 'id',
-  listFields: ['id','numero','brinco','raca','estado','nascimento','ultima_ia','parto','created_at'],
-  searchFields: ['numero','brinco','raca','estado'],
-  sortable: ['numero','brinco','raca','estado','nascimento','ultima_ia','parto','created_at'],
+  listFields: [
+    'id','owner_id','numero','brinco','raca','estado','sexo','categoria',
+    'n_lactacoes','pai','mae','nascimento','ultima_ia','parto','previsao_parto','created_at'
+  ],
+  searchFields: ['numero','brinco','raca','estado','pai','mae'],
+  sortable: [
+    'numero','brinco','raca','estado','sexo','categoria',
+    'n_lactacoes','nascimento','ultima_ia','parto','previsao_parto','created_at'
+  ],
   validateCreate: makeValidator(createSchema),
   validateUpdate: makeValidator(updateSchema),
   defaults: () => ({ created_at: new Date().toISOString() }),

--- a/src/pages/Animais/CadastroAnimal.jsx
+++ b/src/pages/Animais/CadastroAnimal.jsx
@@ -369,11 +369,18 @@ export default function CadastroAnimal({ animais = [], onAtualizar }) {
       const payload = {
         numero,
         brinco,
-        nascimento, // TEXT (dd/mm/aaaa)
+        nascimento,                       // TEXT dd/mm/aaaa
         raca,
-        estado: categoria || "vazia",
-        ...(complementares?.ultimaIA ? { ultima_ia: complementares.ultimaIA } : {}),
-        ...(complementares?.ultimoParto ? { parto: complementares.ultimoParto } : {}),
+        estado: categoria || "vazia",     // mantém compatibilidade com tabela
+        sexo,                             // 'femea' | 'macho'
+        categoria,                        // salva o rótulo mostrado
+        pai: complementares?.pai || "",
+        mae: complementares?.mae || "",
+        n_lactacoes: Number(complementares?.nLactacoes || 0),
+        ultima_ia: complementares?.ultimaIA || "",
+        parto: complementares?.ultimoParto || "",
+        previsao_parto: complementares?.dataPrevistaParto || "",
+        historico: complementares?.historico || null, // opcional
       };
       const inserido = await criarAnimal(payload); // POST /api/v1/animals
 

--- a/src/pages/Animais/Plantel.jsx
+++ b/src/pages/Animais/Plantel.jsx
@@ -1,11 +1,19 @@
 import React, { useState } from "react";
 
-function calcPrevisaoParto(brDate) {
-  if (!brDate || brDate.length !== 10) return null;
-  const [d, m, y] = brDate.split("/");
-  const dt = new Date(`${y}-${m}-${d}`);
-  dt.setDate(dt.getDate() + 280);
-  return dt.toLocaleDateString("pt-BR");
+function idadeTexto(nascimento) {
+  if (!nascimento || nascimento.length !== 10) return "—";
+  const [d, m, a] = nascimento.split("/").map(Number);
+  const dt = new Date(a, m - 1, d);
+  const meses = Math.max(0, Math.floor((Date.now() - dt) / (1000 * 60 * 60 * 24 * 30.44)));
+  return `${Math.floor(meses / 12)}a ${meses % 12}m`;
+}
+
+function del(parto) {
+  if (!parto || parto.length !== 10) return "—";
+  const [d, m, a] = parto.split("/").map(Number);
+  const dt = new Date(a, m - 1, d);
+  const dias = Math.max(0, Math.round((Date.now() - dt) / 86400000));
+  return `${dias}`;
 }
 
 const tableClasses = "w-full border-separate [border-spacing:0_8px] text-sm text-[#333] table-fixed whitespace-nowrap";
@@ -13,12 +21,26 @@ const thBase = "bg-[#e6f0ff] px-4 py-3 text-left font-bold text-[#1e3a8a] border
 const tdBase = "px-5 py-4 border-b border-[#eee] overflow-hidden text-ellipsis";
 const rowBase = "bg-white shadow-sm hover:bg-[#e0f2ff] transition-colors";
 const rowAlt  = "even:bg-[#f3f4f6]";
-const hoverTH = (i, hc) => i===hc ? "bg-[rgba(33,150,243,0.08)]" : "";
-const hoverTD = (i, hc) => i===hc ? "bg-[rgba(33,150,243,0.08)]" : "";
+const hoverTH = (i, hc) => (i === hc ? "bg-[rgba(33,150,243,0.08)]" : "");
+const hoverTD = (i, hc) => (i === hc ? "bg-[rgba(33,150,243,0.08)]" : "");
 
 export default function Plantel({ animais = [] }) {
   const [hoverCol, setHoverCol] = useState(null);
-  const colunas = ["Número","Brinco","Lactações","DEL","Categoria","Idade","Últ. IA","Parto","Raça","Pai","Mãe","Previsão Parto","Ação"];
+  const colunas = [
+    "Número",
+    "Brinco",
+    "Lactações",
+    "DEL",
+    "Categoria",
+    "Idade",
+    "Últ. IA",
+    "Parto",
+    "Raça",
+    "Pai",
+    "Mãe",
+    "Previsão Parto",
+    "Ação",
+  ];
 
   return (
     <div className="w-full px-8 py-6 font-sans">
@@ -26,10 +48,12 @@ export default function Plantel({ animais = [] }) {
         <thead>
           <tr>
             {colunas.map((c, i) => (
-              <th key={c}
-                  onMouseEnter={() => setHoverCol(i)}
-                  onMouseLeave={() => setHoverCol(null)}
-                  className={`${thBase} ${hoverTH(i, hoverCol)}`}>
+              <th
+                key={c}
+                onMouseEnter={() => setHoverCol(i)}
+                onMouseLeave={() => setHoverCol(null)}
+                className={`${thBase} ${hoverTH(i, hoverCol)}`}
+              >
                 {c}
               </th>
             ))}
@@ -37,16 +61,27 @@ export default function Plantel({ animais = [] }) {
         </thead>
         <tbody>
           {(Array.isArray(animais) ? animais : []).map((v, idx) => {
-            const lastCalving = v.ultimoParto || (v.partos?.length ? v.partos[v.partos.length - 1].data : "—");
             const row = [
-              v.numero, v.brinco, v.nLactacoes ?? "—", v.del ?? "—", v.categoria, v.idade,
-              v.ultimaIA || "—", lastCalving, v.raca, v.pai || "—", v.mae || "—",
-              calcPrevisaoParto(v.ultimaIA) || "—", ""
+              v.numero,
+              v.brinco,
+              v.n_lactacoes ?? "—",
+              del(v.parto),
+              v.categoria ?? "—",
+              idadeTexto(v.nascimento),
+              v.ultima_ia ?? "—",
+              v.parto ?? "—",
+              v.raca ?? "—",
+              v.pai ?? "—",
+              v.mae ?? "—",
+              v.previsao_parto ?? "—",
+              "",
             ];
             return (
               <tr key={idx} className={`${rowBase} ${rowAlt}`}>
                 {colunas.map((_, i) => (
-                  <td key={i} className={`${tdBase} ${hoverTD(i, hoverCol)}`}>{row[i]}</td>
+                  <td key={i} className={`${tdBase} ${hoverTD(i, hoverCol)}`}>
+                    {row[i]}
+                  </td>
                 ))}
               </tr>
             );
@@ -56,3 +91,4 @@ export default function Plantel({ animais = [] }) {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- expandir tabela `animals` com sexo, genealogia e campos reprodutivos
- permitir criação/listagem desses campos na API
- enviar e exibir dados complementares no cadastro e plantel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add118f7d883288f5efa54f3126f4d