### PR TITLE
feat: add sires resource with file upload

### DIFF
--- a/backend/resources/crudRouter.js
+++ b/backend/resources/crudRouter.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import { v4 as uuid } from 'uuid';
 
-function extractUserId(req) {
+export function extractUserId(req) {
   // tenta vários formatos comuns de middleware
   const u = req.user || req.auth || {};
   let id = u.id || u.userId || req.userId || u.sub || null;


### PR DESCRIPTION
## Summary
- add Sires tables and CRUD routes with PDF upload support
- expose uploaded files through /files static route
- export extractUserId helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0ebb72f483289b21e0b94a8214a0