### PR TITLE
Add sire PDF retrieval and viewing in animal form

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -96,6 +96,24 @@ export async function listSireFiles(id) {
   return res.data;
 }
 
+// baixa o PDF da ficha do touro
+export async function getSirePdf(sireId) {
+  // ajuste a rota caso sua API use outro caminho
+  const res = await api.get(path(`/v1/sires/${sireId}/pdf`), {
+    responseType: 'blob',
+  });
+  // tenta extrair o filename do header (opcional)
+  let filename = 'ficha.pdf';
+  const cd = res.headers?.['content-disposition'] || res.headers?.['Content-Disposition'];
+  if (cd) {
+    const m = /filename\*=UTF-8''([^;]+)|filename="?([^"]+)"?/i.exec(cd);
+    filename = decodeURIComponent(m?.[1] || m?.[2] || filename);
+  }
+  const blob = new Blob([res.data], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  return { url, filename };
+}
+
 /* ================== REPRODUÇÃO ================== */
 export async function inserirInseminacao(id, data) {
   const res = await api.post(path(`/reproducao/${id}/inseminacoes`), data);


### PR DESCRIPTION
## Summary
- add `getSirePdf` helper for downloading sire PDF files
- allow viewing sire PDF in complementary animal form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae14ba9cf08328b63bbee3ec25fd2e