### PR TITLE
Add sire PDF upload endpoint and frontend helpers

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -100,8 +100,8 @@ app.use("/api/data", express.static(path.join(__dirname, "data")));
 // Garante pasta para dumps/recuperações manuais (compatível com seu antigo)
 fs.mkdirSync(path.join(__dirname, "dadosExcluidos"), { recursive: true });
 
-// servir arquivos enviados (ex.: PDFs de touros)
-app.use('/files', express.static(path.join(process.cwd(), 'storage', 'uploads')));
+// (opcional) servir uploads (ex.: PDFs de touros)
+app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 
 // Rotas da API
 // ⚠️ Mantenha por enquanto só as essenciais.

--- a/src/api.js
+++ b/src/api.js
@@ -84,7 +84,7 @@ export async function createSire(data) {
 
 export async function uploadSirePdf(sireId, file) {
   const form = new FormData();
-  form.append("file", file);
+  form.append("file", file); // <<< mantenha "file"
   const res = await api.post(`/api/v1/sires/${sireId}/pdf`, form, {
     headers: { "Content-Type": "multipart/form-data" },
   });
@@ -96,22 +96,10 @@ export async function listSireFiles(id) {
   return res.data;
 }
 
-// baixa o PDF da ficha do touro
+// Para abrir:
 export async function getSirePdf(sireId) {
-  // ajuste a rota caso sua API use outro caminho
-  const res = await api.get(path(`/v1/sires/${sireId}/pdf`), {
-    responseType: 'blob',
-  });
-  // tenta extrair o filename do header (opcional)
-  let filename = 'ficha.pdf';
-  const cd = res.headers?.['content-disposition'] || res.headers?.['Content-Disposition'];
-  if (cd) {
-    const m = /filename\*=UTF-8''([^;]+)|filename="?([^"]+)"?/i.exec(cd);
-    filename = decodeURIComponent(m?.[1] || m?.[2] || filename);
-  }
-  const blob = new Blob([res.data], { type: 'application/pdf' });
-  const url = URL.createObjectURL(blob);
-  return { url, filename };
+  const res = await api.get(`/api/v1/sires/${sireId}/pdf`, { responseType: "blob" });
+  return res.data; // Blob
 }
 
 /* ================== REPRODUÇÃO ================== */


### PR DESCRIPTION
## Summary
- handle sire PDF uploads using multer memory storage
- serve uploaded files and register /api/v1/sires routes
- expose upload and download helpers on the frontend

## Testing
- `npm test`
- `cd backend && npm test` *(fails: Missing script "test")*
- `npm i multer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c80b410832882e1cfebc412b873