### PR TITLE
feat: integrate sire pdf helpers

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -77,9 +77,11 @@ export async function getSires({ q, page, limit } = {}) {
   return res.data;
 }
 
-export async function createSire(data) {
-  const res = await api.post(path('/v1/sires'), data);
-  return res.data;
+// --- FICHA DO TOURO ---
+// cria o touro (apenas dados básicos)
+export async function createSire(nome) {
+  const res = await api.post("/api/v1/sires", { name: nome });
+  return res.data; // deve retornar { id, name, ... }
 }
 
 export async function uploadSirePdf(sireId, file) {

--- a/src/pages/Animais/FichasTouros.jsx
+++ b/src/pages/Animais/FichasTouros.jsx
@@ -27,19 +27,9 @@ export function ImportarFichaTouro({ onFechar, onSalvar }) {
       alert("Preencha o nome do touro e selecione o PDF.");
       return;
     }
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const base64data = reader.result;
-      const touroObj = {
-        nome: nomeTouro,
-        arquivoBase64: base64data, // pronto para <iframe>
-        texto: "(Texto não extraído — sem pdfjs)",
-        dataUpload: new Date().toISOString(),
-      };
-      onSalvar?.(touroObj);
-      onFechar?.();
-    };
-    reader.readAsDataURL(arquivo);
+    // devolve o File diretamente (sem converter para base64)
+    onSalvar?.({ nome: nomeTouro, file: arquivo });
+    onFechar?.();
   };
 
   return (


### PR DESCRIPTION
## Summary
- add API helpers to create sire records and manage PDF files
- wire up bull PDF import/view flows in animal registration
- simplify bull import modal to return raw file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1ef1e3ac83288ca2c20f0f5297fd