### PR TITLE
feat: add Sires upload API and improve backup middleware

### DIFF
--- a/backend/middleware/backupOnWrite.js
+++ b/backend/middleware/backupOnWrite.js
@@ -1,39 +1,48 @@
-// backend/middleware/backupOnWrite.js
-import fs from "node:fs";
 import path from "node:path";
-import jwt from "jsonwebtoken";
+import fsp from "node:fs/promises";
 
 const FILE_ROOT = process.env.FILE_STORAGE_ROOT || "./storage";
-const JWT_SECRET = process.env.JWT_SECRET || "dev-secret-altere";
 
-function ensureDir(p) { if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true }); }
-function ymd(d=new Date()){const y=d.getFullYear(),m=String(d.getMonth()+1).padStart(2,"0"),dd=String(d.getDate()).padStart(2,"0");return `${y}-${m}-${dd}`;}
-function hms(d=new Date()){const h=String(d.getHours()).padStart(2,"0"),m=String(d.getMinutes()).padStart(2,"0"),s=String(d.getSeconds()).padStart(2,"0");return `${h}${m}${s}`;}
-function getUserId(req){try{const a=req.headers.authorization||"";if(!a.startsWith("Bearer "))return "anon";const t=a.slice(7);const dec=jwt.verify(t,JWT_SECRET);return dec?.sub||"anon";}catch{return "anon";}}
+function safeName(str) {
+  return String(str)
+    .replace(/[\\/:*?"<>|]/g, "-")
+    .replace(/\s+/g, "_")
+    .slice(0, 180);
+}
 
-export function backupOnWrite(req, res, next) {
-  const isWrite = ["POST","PUT","PATCH","DELETE"].includes(req.method);
-  if (!isWrite || !req.originalUrl.startsWith("/api/")) return next();
+async function ensureDir(dir) {
+  await fsp.mkdir(dir, { recursive: true });
+}
 
-  const started = new Date();
-  const userId = String(getUserId(req));
-  const reqBody = req.body;
+export async function backupOnWrite(req, _res, next) {
+  try {
+    const root = path.resolve(FILE_ROOT, "_backups");
+    const userId = String(req.user?.id || "anon");
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const hh = String(now.getHours()).padStart(2, "0");
+    const mi = String(now.getMinutes()).padStart(2, "0");
+    const ss = String(now.getSeconds()).padStart(2, "0");
 
-  const oldJson = res.json.bind(res);
-  res.json = (payload) => {
-    try {
-      const base = path.resolve(FILE_ROOT, "_backups", userId, ymd(started));
-      ensureDir(base);
-      const slug = req.originalUrl.replace(/[^\w/-]+/g,"_").slice(0,80).replace(/^_+|_+$/g,"");
-      const file = path.join(base, `${hms(started)}-${req.method}-${slug||"req"}.json`);
-      const record = { meta:{ ts: started.toISOString(), method: req.method, url: req.originalUrl, userId },
-                       request: reqBody, response: payload };
-      fs.writeFileSync(file, JSON.stringify(record, null, 2));
-    } catch (e) {
-      console.error("backupOnWrite error:", e?.message || e);
-    }
-    return oldJson(payload);
-  };
+    const dayDir = path.join(root, userId, `${yyyy}-${mm}-${dd}`);
+    await ensureDir(dayDir);
 
+    const filename = `${hh}${mi}${ss}-${req.method}-${safeName(req.originalUrl)}.json`;
+    const filePath = path.join(dayDir, filename);
+
+    const payload = {
+      method: req.method,
+      url: req.originalUrl,
+      headers: req.headers,
+      body: req.body && Object.keys(req.body).length ? req.body : undefined,
+      at: now.toISOString(),
+    };
+
+    await fsp.writeFile(filePath, JSON.stringify(payload, null, 2));
+  } catch (err) {
+    console.warn("[backupOnWrite] warn:", err.message);
+  }
   next();
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -52,7 +52,10 @@ app.use(morgan("dev"));
 // Ativa multi-tenant/backup só quando quiser
 if (BACKUP_ENABLED) {
   app.use(tenantContext);
-  app.use(backupOnWrite);
+  app.use((req, res, next) => {
+    if (req.path.startsWith("/api/v1/sires")) return next();
+    return backupOnWrite(req, res, next);
+  });
 }
 
 // Garante tabelas e registra recursos adicionais


### PR DESCRIPTION
## Summary
- make backupOnWrite async and create directories safely
- add Sires POST upload and PDF retrieval with DB persistence
- skip backup middleware for /api/v1/sires routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae27fa4a4083288674458c14e69912