### PR TITLE
fix: handle sires upload without 400

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -46,8 +46,13 @@ const PORT = process.env.PORT || 3001;
 
 const app = express();
 app.use(cors());
-app.use(express.json({ limit: "10mb" }));
 app.use(morgan("dev"));
+
+// 🚩 1) Monte a rota de upload ANTES de tocar no body (json/urlencoded/backup)
+app.use('/api/v1/sires', siresRoutes);
+
+// Parsers para o restante da API (depois do upload)
+app.use(express.json({ limit: "10mb" }));
 
 // Ativa multi-tenant/backup só quando quiser
 if (BACKUP_ENABLED) {
@@ -117,7 +122,7 @@ app.use('/api/v1/animals/metrics', animalsMetrics);
 app.use('/api/v1/products/metrics', productsMetrics);
 
 // === Recursos v1 ===
-app.use('/api/v1/sires', siresRoutes);
+// (siresRoutes já foi montada acima, antes dos parsers)
 app.use('/api/v1/animals', animalsResource);
 app.use('/api/v1/products', productsResource);
 

--- a/src/api.js
+++ b/src/api.js
@@ -14,8 +14,12 @@ const api = axios.create({
 
 // injeta token (se houver) e permite FormData sem forçar JSON
 api.interceptors.request.use((config) => {
-  if (config.data instanceof FormData && config.headers) {
-    delete config.headers['Content-Type'];
+  if (config.data instanceof FormData) {
+    if (config.headers) {
+      delete config.headers['Content-Type'];
+    }
+    // impede qualquer transform de JSON
+    config.transformRequest = [(d) => d];
   }
   const token = localStorage.getItem('token');
   if (token) config.headers.Authorization = `Bearer ${token}`;

--- a/src/pages/Animais/FichasTouros.jsx
+++ b/src/pages/Animais/FichasTouros.jsx
@@ -1,6 +1,5 @@
 // src/pages/Animais/FichasTouros.jsx
 import React, { useEffect, useRef, useState } from "react";
-import api from "../../api";
 
 /* ===============================
    📎 Importar Ficha do Touro (upload PDF)
@@ -39,13 +38,15 @@ export function ImportarFichaTouro({ onSucesso, onFechar }) {
       const fd = new FormData();
       fd.append("name", nome.trim());
       fd.append("pdf", arquivo);
-      const { data } = await api.post("/v1/sires", fd);
+      const resp = await fetch("/api/v1/sires", { method: "POST", body: fd, credentials: "include" });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) throw new Error(data?.message || `Falha ${resp.status}`);
       onSucesso?.(data);
       window.open(`/api/v1/sires/${data.id}/pdf`, "_blank", "noopener");
       onFechar?.();
     } catch (err) {
       console.error("Falha ao anexar a ficha do touro:", err);
-      alert(err?.response?.data?.message || "Não foi possível anexar a ficha.");
+      alert(err?.message || "Não foi possível anexar a ficha.");
     } finally {
       setSalvando(false);
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,9 +9,11 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/api": {
-        target: "http://localhost:3001",
+      '/api': {
+        target: 'http://localhost:3001',
         changeOrigin: true,
+        secure: false,
+        ws: false,
       },
     },
   },


### PR DESCRIPTION
## Summary
- mount `/api/v1/sires` before body parsers so multer sees raw multipart
- remove forced headers and JSON transform for `FormData` requests
- upload sire sheets via `fetch` to bypass axios quirks
- adjust Vite proxy config to avoid body rewriting

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae35b70a9883288f6d0f65979a2c98